### PR TITLE
Add apps.py with default_auto_field configuration for Django 3.2

### DIFF
--- a/wagtail_image_import/apps.py
+++ b/wagtail_image_import/apps.py
@@ -1,0 +1,8 @@
+from django.apps import AppConfig
+
+
+class WagtailImageImportAppConfig(AppConfig):
+    label = "wagtail_image_import"
+    name = "wagtail_image_import"
+    verbose_name = "Wagtail Image Import"
+    default_auto_field = "django.db.models.AutoField"


### PR DESCRIPTION
Silences the 

```
wagtail_image_import.DriveIDMapping: (models.W042) Auto-created primary key used when not defining a primary key type, by default 'django.db.models.AutoField'.
	HINT: Configure the DEFAULT_AUTO_FIELD setting or the AppConfig.default_auto_field attribute to point to a subclass of AutoField, e.g. 'django.db.models.BigAutoField'.
```
warning 